### PR TITLE
Fixed batch processing error when using csv for points and edited for…

### DIFF
--- a/src/main/java/com/mycompany/imagej/SpatialPathologyPlugin_.java
+++ b/src/main/java/com/mycompany/imagej/SpatialPathologyPlugin_.java
@@ -493,9 +493,11 @@ public class SpatialPathologyIJMJava_ implements PlugIn {
                 }
                 
                 WindowManager.getCurrentImage().setOverlay(overlay);
-                new WaitForUserDialog(
-                        "Please click OK to confirm your points")
-                        .show();
+                new WaitForUserDialog("Please click OK to confirm your points").show();
+                RoiManager roiManager = RoiManager.getInstance();
+                roiManager.setVisible(true);
+                roiManager.close();
+
 
             } else {
                 // Code for manual point input


### PR DESCRIPTION
…matting

The issue came from the roiManager searching for a previously established roi manager from the first image rather than the one for the second image (JUnit list error).